### PR TITLE
Add support (model codes) for 2014 and 2017 generation.

### DIFF
--- a/jvc_projector/jvc_projector.py
+++ b/jvc_projector/jvc_projector.py
@@ -161,6 +161,8 @@ class JVCProjector:
             "B2A2": "NX7",
             "B2A3": "NX5",
             "B5B1": "NP5",
+            "XHR1": "X570R",
+            "XHR3": "X770R||X970R",
             "XHP1": "X5000",
             "XHP2": "XC6890",
             "XHP3": "X7000||X9000",

--- a/jvc_projector/jvc_projector.py
+++ b/jvc_projector/jvc_projector.py
@@ -164,6 +164,9 @@ class JVCProjector:
             "XHP1": "X5000",
             "XHP2": "XC6890",
             "XHP3": "X7000||X9000",
+            "XHK1": "X500R",
+            "XHK2": "RS4910",
+            "XHK3": "X700R||X900R",
         }
         model_res = self._replace_headers(res).decode()
         self.logger.debug(model_res)


### PR DESCRIPTION
I want to use this library and HA integration with my X500R, I'm starting with adding the model codes so these older generations can be correctly identified.

Only tested with X500R.