### PR TITLE
Add get source status command

### DIFF
--- a/jvc_projector/commands.py
+++ b/jvc_projector/commands.py
@@ -31,6 +31,7 @@ class ACKs(Enum):
     hdmi_ack = b"IS"
     hdr_ack = b"IF"
     model = b"MD"
+    source_ack = b"SC"
 
 
 class InputModes(Enum):
@@ -254,6 +255,12 @@ class AspectRatioModes(Enum):
     native = b"4"
 
 
+class SourceStatuses(Enum):
+    logo = b"\x00"
+    no_signal = b"0"
+    signal = b"1"
+
+
 class Commands(Enum):
 
     # these use ! unless otherwise indicated
@@ -333,3 +340,6 @@ class Commands(Enum):
 
     # e-shift
     eshift_mode = b"PMUS", EshiftModes, ACKs.picture_ack
+
+    # source status
+    source_status = b"SC", SourceStatuses, ACKs.source_ack

--- a/jvc_projector/jvc_projector.py
+++ b/jvc_projector/jvc_projector.py
@@ -23,6 +23,7 @@ from jvc_projector.commands import (
     LowLatencyModes,
     ContentTypes,
     HdrProcessing,
+    SourceStatuses,
     TheaterOptimizer,
     HdrData,
     LampPowerModes,
@@ -576,6 +577,13 @@ class JVCProjector:
         """
         state, _ = self._do_reference_op("aspect_ratio", ACKs.hdmi_ack)
         return AspectRatioModes(state.replace(ACKs.hdmi_ack.value, b"")).name
+
+    def get_source_status(self) -> str:
+        """
+        Return source status
+        """
+        state, _ = self._do_reference_op("source_status", ACKs.source_ack)
+        return SourceStatuses(state.replace(ACKs.source_ack.value, b"")).name
 
     def _get_power_state(self) -> str:
         """


### PR DESCRIPTION
I'm working to get the jvc_homeassistant custom integration set up with my NX5. One of the issues I see is that when the projector is on and there's no input, the get_hdr_data command fails and goes into lengthy retries, which causes HA to take a long time to complete a state update.

This PR adds an API to JVCProjector that queries the source status. I hope to use that from another PR in jvc_homeassistant to check for a signal before calling get_hdr_data.

I tested this API with my NX5.