### PR TITLE
Add get_lamp_time and get_software_version

### DIFF
--- a/jvc_projector/commands.py
+++ b/jvc_projector/commands.py
@@ -29,7 +29,7 @@ class ACKs(Enum):
     pj_req = b"PJREQ"
     install_acks = b"IN"
     hdmi_ack = b"IS"
-    hdr_ack = b"IF"
+    info_ack = b"IF"
     model = b"MD"
 
 
@@ -276,6 +276,9 @@ class Commands(Enum):
     # response -> \x40\x89\x01\x4D\x44(the model code)\x0A
     get_model = b"MD"
 
+    # software version
+    get_software_version = b"IFSV", str, ACKs.info_ack
+
     # content type
     content_type = b"PMAT", ContentTypes, ACKs.picture_ack
 
@@ -283,7 +286,7 @@ class Commands(Enum):
     hdr_processing = b"PMHP", HdrProcessing, ACKs.picture_ack
 
     # hdr data
-    hdr_data = b"IFHR", HdrData, ACKs.hdr_ack
+    hdr_data = b"IFHR", HdrData, ACKs.info_ack
 
     # theater optimizer on/off
     theater_optimizer = b"PMNM", TheaterOptimizer, ACKs.picture_ack
@@ -323,6 +326,9 @@ class Commands(Enum):
 
     # Lamp power
     lamp_power = b"PMLP", LampPowerModes, ACKs.picture_ack
+
+    # Lamp time
+    lamp_time = b"IFLT", int, ACKs.info_ack
 
     # Lens Aperture commands
     aperture = b"PMDI", ApertureModes, ACKs.picture_ack

--- a/jvc_projector/jvc_projector.py
+++ b/jvc_projector/jvc_projector.py
@@ -527,6 +527,13 @@ class JVCProjector:
         """
         state, _ = self._do_reference_op("input_level", ACKs.hdmi_ack)
         return InputLevel(state.replace(ACKs.hdmi_ack.value, b"")).name
+    
+    def get_software_version(self) -> str:
+        """
+        Get the current software version
+        """
+        state, _ = self._do_reference_op("get_software_version", ACKs.info_ack)
+        return state.replace(ACKs.info_ack.value, b"")
 
     def get_content_type(self) -> str:
         """
@@ -546,7 +553,7 @@ class JVCProjector:
         """
         Get the current hdr mode -> sdr, hdr10_plus, etc
         """
-        state, _ = self._do_reference_op("hdr_data", ACKs.hdr_ack)
+        state, _ = self._do_reference_op("hdr_data", ACKs.info_ack)
         return HdrData(state.replace(ACKs.hdr_ack.value, b"")).name
 
     def get_lamp_power(self) -> str:
@@ -555,6 +562,13 @@ class JVCProjector:
         """
         state, _ = self._do_reference_op("lamp_power", ACKs.picture_ack)
         return LampPowerModes(state.replace(ACKs.picture_ack.value, b"")).name
+
+    def get_lamp_time(self) -> int:
+        """
+        Get the current lamp time
+        """
+        state, _ = self._do_reference_op("lamp_time", ACKs.info_ack)
+        return int(state.replace(ACKs.info_ack.value, b""), 16)
 
     def get_laser_power(self) -> str:
         """


### PR DESCRIPTION
Tested with an NX5.

The docs give an example of returning "03-005" to mean version 03.005. However, my NX5 (on 3.52) returned "0352PV". So, get_software_version just returns whatever the projector returned, without any attempt to parse it into something nicer.

Fixes #21